### PR TITLE
Incorrect module path in unit-testing README

### DIFF
--- a/packages/unit-testing/README.md
+++ b/packages/unit-testing/README.md
@@ -65,7 +65,7 @@ The `jest.config.js` file must follow a specific structure. Depending on your SD
 
 - For Account Customization Projects:
 ```javascript
-const SuiteCloudJestConfiguration = require("@oracle/suitecloud-unit-testing/SuiteCloudJestConfiguration");
+const SuiteCloudJestConfiguration = require("@oracle/suitecloud-unit-testing");
 
 module.exports = SuiteCloudJestConfiguration.build({
   projectFolder: 'src', //or your SDF project folder
@@ -75,7 +75,7 @@ module.exports = SuiteCloudJestConfiguration.build({
 
 - For SuiteApps:
 ```javascript
-const SuiteCloudJestConfiguration = require("@oracle/suitecloud-unit-testing/SuiteCloudJestConfiguration");
+const SuiteCloudJestConfiguration = require("@oracle/suitecloud-unit-testing");
 
 module.exports = SuiteCloudJestConfiguration.build({
   projectFolder: 'src', //or your SDF project folder


### PR DESCRIPTION
The path specified when requiring `SuiteCloudJestConfiguration` for the Additional Configuration example is missing the `jest-configuration` directory. Suggest fixing by either removing `SuiteCloudJestConfiguration` from the path or adding the `jest-configuration` directory in the path