### PR TITLE
feature/suitescript-stubs small fixes on stubs

### DIFF
--- a/packages/unit-testing/stubs/https/SecretKey.js
+++ b/packages/unit-testing/stubs/https/SecretKey.js
@@ -12,15 +12,45 @@ define([], function() {
      * @constructor
      */    
     function SecretKey() {
+        /**
+         * The GUID associated with the secret key.
+         * @name SecretKey#guid
+         * @type {string}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2015.2
+         */        
+        this.guid = undefined;        
+        /**
+         * The encoding used for the clear text value of the secret key.
+         * @name SecretKey#encoding
+         * @type {string}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2015.2
+         */        
+        this.encoding = undefined;        
+        /**
+         * Returns the object type name (crypto.SecretKey)
+         * @restriction Server SuiteScript only
+         * @governance none
+         * @return {string}
+         *
+         * @since 2015.2
+         */        
+        this.toString = function() {};        
         
         /**
-         * @type string
+         * get JSON format of the object
+         * @restriction Server SuiteScript only
+         * @governance none
+         * @return {Object}
+         *
+         * @since 2020.1
          */        
-        this.guid = undefined;
-        /**
-         * @type string
-         */        
-        this.encoding = undefined;
+        this.toJSON = function() {};   
     }
 
     return new SecretKey();

--- a/packages/unit-testing/stubs/record/Field.js
+++ b/packages/unit-testing/stubs/record/Field.js
@@ -12,7 +12,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.label = undefined;
+		this.label = undefined;
 		/**
 		 * Return id of the field
 		 * @name Field#id
@@ -21,7 +21,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.id = undefined;
+		this.id = undefined;
 		/**
 		 * Disabled state of the field
 		 * @name Field#isDisabled
@@ -29,7 +29,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.isDisabled = undefined;
+		this.isDisabled = undefined;
 		/**
 		 * Display state of the field
 		 * @name Field#isDisplay
@@ -37,7 +37,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.isDisplay = undefined;
+		this.isDisplay = undefined;
 		/**
 		 * Mandatory state of the field
 		 * @name Field#isMandatory
@@ -45,7 +45,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.isMandatory = undefined;
+		this.isMandatory = undefined;
 		/**
 		 * Read Only state of the field
 		 * @name Field#isReadOnly
@@ -53,7 +53,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.isReadOnly = undefined;
+		this.isReadOnly = undefined;
 		/**
 		 * Visible state of the field
 		 * @name Field#isVisible
@@ -61,7 +61,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.isVisible = undefined;
+		this.isVisible = undefined;
 		/**
 		 * Return type of the field
 		 * @name Field#type
@@ -70,7 +70,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.type = undefined;
+		this.type = undefined;
 		/**
 		 * Return the sublistId of the field
 		 * @name Field#sublistId
@@ -79,7 +79,7 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.sublistId = undefined;
+		this.sublistId = undefined;
 		/**
 		 * Returns if the field is a popup
 		 * @name Field#isPopup
@@ -88,21 +88,21 @@ define([], function () {
 		 * @since 2015.2
 		 */
 
-		this.prototype.isPopup = undefined;
+		this.isPopup = undefined;
 		/**
 		 * get JSON format of the object
 		 * @return {{id: *, label: *, type: *}}
 		 *
 		 */
 
-		this.prototype.toJSON = function (options) {};
+		this.toJSON = function (options) {};
 
 		/**
 		 * @return {string}
 		 *
 		 */
 
-		this.prototype.toString = function (options) {};
+		this.toString = function (options) {};
 	}
 
 	return new Field();

--- a/packages/unit-testing/stubs/record/Sublist.js
+++ b/packages/unit-testing/stubs/record/Sublist.js
@@ -29,7 +29,7 @@ define([], function () {
          * @readonly
          */
         
-        this.prototype.getType = function(options) {};
+        this.getType = function(options) {};
         
         /**
          * The sublist is changed
@@ -38,7 +38,7 @@ define([], function () {
          * @readonly
          */
         
-        this.prototype.isChanged = function(options) {};
+        this.isChanged = function(options) {};
         
         /**
          * The sublist is hidden
@@ -47,7 +47,7 @@ define([], function () {
          * @readonly
          */
         
-        this.prototype.isHidden = function(options) {};
+        this.isHidden = function(options) {};
         
         /**
          * The sublist is display
@@ -56,7 +56,7 @@ define([], function () {
          * @readonly
          */
         
-        this.prototype.isDisplay = function(options) {};
+        this.isDisplay = function(options) {};
         
         /**
          * A flag to indicate whether or not the sublist supports multi-line buffer feature.
@@ -65,21 +65,21 @@ define([], function () {
          * @readonly
          */
         
-        this.prototype.isMultilineEditable = function(options) {};
+        this.isMultilineEditable = function(options) {};
         
         /**
          * Returns the object type name (sublist.Sublist)
          * @returns {string}
          */
         
-        this.prototype.toString = function(options) {};
+        this.toString = function(options) {};
         
         /**
          * JSON.stringify() implementation.
          * @returns {{id: string, type: string, isChanged: boolean, isDisplay: boolean}}
          */
         
-        this.prototype.toJSON = function(options) {};
+        this.toJSON = function(options) {};
     }
 
     return new Sublist();

--- a/packages/unit-testing/stubs/search/search.js
+++ b/packages/unit-testing/stubs/search/search.js
@@ -1,4 +1,4 @@
-define(['./SearchInstance', './Column', './Filter', './Result, ./Setting'], function (Search, Column, Filter, Result, Setting) {
+define(['./SearchInstance', './Column', './Filter', './Result', './Setting'], function (Search, Column, Filter, Result, Setting) {
 	/**
 	 * SuiteScript search common module
 	 * Load the search module to create and run on-demand or saved searches and analyze and iterate through the search results.


### PR DESCRIPTION
Fixes missing quotes in define statement of N/search module stub.
Remove .prototype from N/record/sublist and N/record/field stubs.
Add missing methods in N/https/secretkey stub.