### PR TITLE
reduce-limit-for-number-of-scripts-per-import-call

### DIFF
--- a/packages/node-cli/src/commands/object/import/ImportObjectsAction.js
+++ b/packages/node-cli/src/commands/object/import/ImportObjectsAction.js
@@ -41,8 +41,8 @@ const COMMAND_FLAGS = {
 const LIST_OBJECTS_COMMAND_NAME = 'object:list';
 const IMPORT_OBJECTS_COMMAND_TYPE_PARAM_ALL = 'ALL';
 const IMPORT_OBJECTS_COMMAND_SCRIPT_ID_PARAM_ALL = 'ALL';
-const NUMBER_OF_SCRIPTS = 35;
-const MAX_PARALLEL_EXECUTIONS = 5;
+const NUMBER_OF_SCRIPTS = 8;
+const MAX_PARALLEL_EXECUTIONS = 4;
 
 module.exports = class ImportObjectsAction extends BaseAction {
 	constructor(options) {
@@ -99,7 +99,7 @@ module.exports = class ImportObjectsAction extends BaseAction {
 				successfulImports: [],
 				errorImports: [],
 			};
-			const arrayOfPromises = [];
+			let arrayOfPromises = [];
 			const numberOfSdkCalls = Math.ceil(scriptIdArray.length / NUMBER_OF_SCRIPTS);
 			const numberOfSteps = Math.ceil(numberOfSdkCalls / MAX_PARALLEL_EXECUTIONS);
 
@@ -125,6 +125,7 @@ module.exports = class ImportObjectsAction extends BaseAction {
 						action: Promise.all(arrayOfPromises),
 						message: NodeTranslationService.getMessage(MESSAGES.IMPORTING_OBJECTS, (i + 1) / MAX_PARALLEL_EXECUTIONS, numberOfSteps),
 					});
+					arrayOfPromises = [];
 				}
 			}
 


### PR DESCRIPTION
We need to reduce the number of scripts per import call so that we will not reach the limit and get an error for importobjects. This is the same with pull request https://github.com/oracle/netsuite-suitecloud-sdk/pull/254 (dev branch).