### PR TITLE
Bug fixes for PDPDEVTOOL-790: As a SuiteCloud Developer, I want to interact with the FILE:CREATE command exposed SDK in a interactive mode, so I can create Suite Script files and inject modules in to generate the template in CLI for Node.js (PDPDEVTOOL-4305, PDPDEVTOOL-4303, PDPDEVTOOL-4304, PDPDEVTOOL-4306, PDPDEVTOOL-4307)

### DIFF
--- a/packages/node-cli/messages.json
+++ b/packages/node-cli/messages.json
@@ -34,7 +34,7 @@
 	"COMMAND_CREATEFILE_ENTER_NAME": "Enter a name for the SuiteScript file.",
 	"COMMAND_CREATEFILE_MESSAGE_CREATING_FILE": "Creating SuiteScript file...",
 	"COMMAND_CREATEFILE_MESSAGE_SUITESCRIPT_FILE_CREATED": "The SuiteScript file was created successfully in {0}.",
-	"COMMAND_CREATEFILE_MESSAGE_SUITESCRIPT_FILE_CREATED_WITH_MODULES": "The SuiteScript file was created successfully in {0} with the following modules: {1}",
+	"COMMAND_CREATEFILE_MESSAGE_SUITESCRIPT_FILE_CREATED_WITH_MODULES": "The SuiteScript file was created successfully in {0}\nThe following modules were added to the script: {1}",
 	"COMMAND_CREATEFILE_SELECT_FOLDER": "Select the folder where you want to create the SuiteScript file",
 	"COMMAND_CREATEFILE_SELECT_SUITESCRIPT_MODULES": "Select the SuiteScript modules you want to add to the SuiteScript file",
 

--- a/packages/node-cli/src/commands/file/create/CreateFileAction.js
+++ b/packages/node-cli/src/commands/file/create/CreateFileAction.js
@@ -4,6 +4,7 @@
  */
 'use strict';
 
+const path = require('path');
 const { executeWithSpinner } = require('../../../ui/CliSpinner');
 const { ActionResult } = require('../../../services/actionresult/ActionResult');
 const { FOLDERS } = require('../../../ApplicationConstants');
@@ -61,8 +62,7 @@ module.exports = class CreateFileAction extends BaseAction {
         });
 
         if (operationResult.status === SdkOperationResultUtils.STATUS.SUCCESS) {
-            const suiteScriptFileAbsolutePath = (this._projectFolder + FOLDERS.FILE_CABINET + params[COMMAND_OPTIONS.PATH])
-                .replace(/\\/g, "/");
+            const suiteScriptFileAbsolutePath = path.join(this._projectFolder, FOLDERS.FILE_CABINET, params[COMMAND_OPTIONS.PATH]);
 
             let resultMessage = NodeTranslationService.getMessage(MESSAGES.SUITESCRIPT_FILE_CREATED, suiteScriptFileAbsolutePath);
             if (params.hasOwnProperty(COMMAND_OPTIONS.MODULE)) {

--- a/packages/node-cli/src/commands/file/create/CreateFileInputHandler.js
+++ b/packages/node-cli/src/commands/file/create/CreateFileInputHandler.js
@@ -5,10 +5,11 @@
 'use strict';
 
 const { prompt, Separator } = require('inquirer');
-const { join } = require('path');
+const path = require('path');
 const { FOLDERS } = require('../../../ApplicationConstants');
 const {
     showValidationResults,
+    validateFieldHasNoSpaces,
     validateArrayIsNotEmpty,
     validateFieldIsNotEmpty,
     validateSuiteScriptFileAlreadyExists,
@@ -44,7 +45,7 @@ module.exports = class CreateFileInputHandler extends BaseInputHandler {
         super(options);
 
         this._fileSystemService = new FileSystemService();
-        this._fileCabinetService = new FileCabinetService(join(this._projectFolder, FOLDERS.FILE_CABINET));
+        this._fileCabinetService = new FileCabinetService(path.join(this._projectFolder, FOLDERS.FILE_CABINET));
         this._projectInfoService = new ProjectInfoService(this._projectFolder);
 
         this._accountCustomizationProject = this._projectInfoService.isAccountCustomizationProject();
@@ -127,8 +128,7 @@ module.exports = class CreateFileInputHandler extends BaseInputHandler {
     }
 
     _questionEnterName(parentRelativePath) {
-        const parentAbsolutePath = (this._projectFolder + ApplicationConstants.FOLDERS.FILE_CABINET + parentRelativePath)
-            .replace(/\\/g, "/");
+        const parentAbsolutePath = path.join(this._projectFolder, ApplicationConstants.FOLDERS.FILE_CABINET, parentRelativePath);
 
         return {
             type: CommandUtils.INQUIRER_TYPES.INPUT,
@@ -137,6 +137,7 @@ module.exports = class CreateFileInputHandler extends BaseInputHandler {
             validate: (fieldValue) => showValidationResults(
                 fieldValue,
                 validateFieldIsNotEmpty,
+                validateFieldHasNoSpaces,
                 (fieldValue) => validateSuiteScriptFileAlreadyExists(parentAbsolutePath, fieldValue)
             ),
         };
@@ -152,7 +153,7 @@ module.exports = class CreateFileInputHandler extends BaseInputHandler {
                 folderRestricted = !folderRelativePath.startsWith(SUITESCRIPTS_PATH);
             } else {
                 const applicationId = this._projectInfoService.getApplicationId();
-                const applicationSuiteAppFolderAbsolutePath = join(this._projectFolder, FOLDERS.FILE_CABINET, SUITEAPPS_PATH, '/', applicationId, '/');
+                const applicationSuiteAppFolderAbsolutePath = path.join(this._projectFolder, FOLDERS.FILE_CABINET, SUITEAPPS_PATH, '/', applicationId, '/');
                 const applicationSuiteAppFolderRelativePath = this._fileCabinetService.getFileCabinetRelativePath(applicationSuiteAppFolderAbsolutePath);
                 folderRestricted = !folderRelativePath.startsWith(applicationSuiteAppFolderRelativePath);
             }
@@ -165,7 +166,7 @@ module.exports = class CreateFileInputHandler extends BaseInputHandler {
         }
 
         return this._fileSystemService
-            .getFoldersFromDirectoryRecursively(join(this._projectFolder, FOLDERS.FILE_CABINET))
+            .getFoldersFromDirectoryRecursively(path.join(this._projectFolder, FOLDERS.FILE_CABINET))
             .map(transformFolderToChoicesObjectFuntion);
     }
 

--- a/packages/node-cli/src/commands/file/create/CreateFileInputHandler.js
+++ b/packages/node-cli/src/commands/file/create/CreateFileInputHandler.js
@@ -11,7 +11,7 @@ const {
     showValidationResults,
     validateArrayIsNotEmpty,
     validateFieldIsNotEmpty,
-    validateFileAlreadyExists,
+    validateSuiteScriptFileAlreadyExists,
 } = require('../../../validation/InteractiveAnswersValidator');
 const {
     COMMAND_CREATEFILE: { QUESTIONS },
@@ -137,7 +137,7 @@ module.exports = class CreateFileInputHandler extends BaseInputHandler {
             validate: (fieldValue) => showValidationResults(
                 fieldValue,
                 validateFieldIsNotEmpty,
-                (fieldValue) => validateFileAlreadyExists(parentAbsolutePath, fieldValue)
+                (fieldValue) => validateSuiteScriptFileAlreadyExists(parentAbsolutePath, fieldValue)
             ),
         };
     }

--- a/packages/node-cli/src/metadata/SdkCommandsMetadata.json
+++ b/packages/node-cli/src/metadata/SdkCommandsMetadata.json
@@ -236,7 +236,7 @@
 			"type": {
 				"name": "type",
 				"option": "type",
-				"description": "Specifies the type of the SuiteScript file that you want to create.",
+				"description": "Specifies the type of the SuiteScript file that you want to create. For example, \"ClientScript\"",
 				"mandatory": false,
 				"type": "MULTIPLE",
 				"usage": "ClientScript",
@@ -246,7 +246,7 @@
 			"module": {
 				"name": "module",
 				"option": "module",
-				"description": "Specifies the SuiteScript modules you want to add to the SuiteScript file.",
+				"description": "Specifies the SuiteScript modules you want to add to the SuiteScript file. For example, \"N/record\"",
 				"mandatory": false,
 				"type": "MULTIPLE",
 				"usage": "N/record [...]",

--- a/packages/node-cli/src/metadata/SdkCommandsMetadata.json
+++ b/packages/node-cli/src/metadata/SdkCommandsMetadata.json
@@ -239,7 +239,7 @@
 				"description": "Specifies the type of the SuiteScript file that you want to create.",
 				"mandatory": false,
 				"type": "MULTIPLE",
-				"usage": "N/record [...]",
+				"usage": "ClientScript",
 				"defaultOption": false,
 				"disableInIntegrationMode": true
 			},
@@ -256,10 +256,10 @@
 			"path": {
 				"name": "path",
 				"option": "path",
-				"description": "References the folder or zip file that contains the SDF project.",
+				"description": "Specify the File Cabinet path of the SuiteScript file to create. For example, \"/SuiteScripts/ClientScipt.js\".",
 				"mandatory": true,
 				"type": "SINGLE",
-				"usage": "foo/bar/CliensScript.js",
+				"usage": "\"/SuiteScripts/ClientScript.js\"",
 				"defaultOption": false,
 				"disableInIntegrationMode": true
 			},

--- a/packages/node-cli/src/metadata/SdkCommandsMetadata.json
+++ b/packages/node-cli/src/metadata/SdkCommandsMetadata.json
@@ -241,7 +241,7 @@
 				"type": "MULTIPLE",
 				"usage": "ClientScript",
 				"defaultOption": false,
-				"disableInIntegrationMode": true
+				"disableInIntegrationMode": false
 			},
 			"module": {
 				"name": "module",
@@ -251,7 +251,7 @@
 				"type": "MULTIPLE",
 				"usage": "N/record [...]",
 				"defaultOption": false,
-				"disableInIntegrationMode": true
+				"disableInIntegrationMode": false
 			},
 			"path": {
 				"name": "path",
@@ -261,7 +261,7 @@
 				"type": "SINGLE",
 				"usage": "\"/SuiteScripts/ClientScript.js\"",
 				"defaultOption": false,
-				"disableInIntegrationMode": true
+				"disableInIntegrationMode": false
 			},
 			"project": {
 				"name": "project",

--- a/packages/node-cli/src/metadata/SuiteScriptTypesMetadata.js
+++ b/packages/node-cli/src/metadata/SuiteScriptTypesMetadata.js
@@ -39,7 +39,7 @@ module.exports = [
     },
     {
         id: "Restlet",
-        name: "Portlet",
+        name: "RESTlet",
     },
     {
         id: "ScheduledScript",

--- a/packages/node-cli/src/validation/InteractiveAnswersValidator.js
+++ b/packages/node-cli/src/validation/InteractiveAnswersValidator.js
@@ -4,6 +4,7 @@
  */
 'use strict';
 
+const path = require('path');
 const ApplicationConstants = require('../ApplicationConstants');
 const FileSystemService = require('../services/FileSystemService');
 const NodeTranslationService = require('../services/NodeTranslationService');
@@ -23,10 +24,11 @@ const ALPHANUMERIC_HYPHEN_UNDERSCORE_EXTENDED = /^[a-zA-Z0-9-_ ]+([.]*[a-zA-Z0-9
 const SCRIPT_ID_REGEX = /^[a-z0-9_]+$/;
 const STRING_WITH_SPACES_REGEX = /\s/;
 const XML_FORBIDDEN_CHARACTERS_REGEX = /[<>&'"]/;
-
 const PROJECT_VERSION_FORMAT_REGEX = '^\\d+(\\.\\d+){2}$';
 const SUITEAPP_ID_FORMAT_REGEX = '^' + ALPHANUMERIC_LOWERCASE_REGEX + '(\\.' + ALPHANUMERIC_LOWERCASE_REGEX + '){2}$';
 const SUITEAPP_PUBLISHER_ID_FORMAT_REGEX = '^' + ALPHANUMERIC_LOWERCASE_REGEX + '\\.' + ALPHANUMERIC_LOWERCASE_REGEX + '$';
+
+const FILE_EXTENSION_JS = '.js';
 
 module.exports = {
 	showValidationResults(value, ...funcs) {
@@ -167,9 +169,16 @@ module.exports = {
 			: VALIDATION_RESULT_FAILURE(NodeTranslationService.getMessage(ANSWERS_VALIDATION_MESSAGES.PRODUCTION_DOMAIN));
 	},
 
-	validateFileAlreadyExists(parentFolderPath, filename) {
+	validateSuiteScriptFileAlreadyExists(parentFolderPath, filename) {
+		const filenameParts = path.parse(filename);
+		const filenameExtension = filenameParts.ext;
+		let filenameWithExtension = filename;
+		if (!filenameExtension) {
+			filenameWithExtension = filenameWithExtension + FILE_EXTENSION_JS;
+		}
+
 		const fileSystemService = new FileSystemService();
-		return !fileSystemService.fileExists(parentFolderPath + filename)
+		return !fileSystemService.fileExists(path.join(parentFolderPath, filenameWithExtension))
 			? VALIDATION_RESULT_SUCCESS
 			: VALIDATION_RESULT_FAILURE(NodeTranslationService.getMessage(ANSWERS_VALIDATION_MESSAGES.FILE_ALREADY_EXISTS, parentFolderPath));
 	}


### PR DESCRIPTION
- PDPDEVTOOL-4305: createfile help for -path is incorrect
- PDPDEVTOOL-4303: Incomplete Non-interactive execution message
- PDPDEVTOOL-4304: Script name field validation
- PDPDEVTOOL-4306: No Restlet Script
- PDPDEVTOOL-4307: The path shown after file creation is not OS independent