### PR TITLE
Bug fixes for PDPDEVTOOL-4021: As a SuiteCloud Developer, I want to have the option to Create SuiteCloud Project in VsCode, so I can build from scratch a new Project using this Code Editor

### DIFF
--- a/packages/vscode-extension/src/commands/CreateProject.ts
+++ b/packages/vscode-extension/src/commands/CreateProject.ts
@@ -42,6 +42,12 @@ export default class CreateProject extends BaseAction {
         }
     }
 
+    protected validate(): { valid: false; message: string } | { valid: true } {
+        return {
+            valid: true,
+        };
+	}
+
     private async openProjectInNewWindow(projectAbsolutePath: string): Promise<void> {
         const openProjectInNewWindow = await window.showInformationMessage(
             this.translationService.getMessage(CREATE_PROJECT.MESSAGES.OPEN_PROJECT),
@@ -51,7 +57,7 @@ export default class CreateProject extends BaseAction {
 
         commands.executeCommand(
             VSCODE_OPEN_FOLDER_COMMAND,
-             Uri.file(projectAbsolutePath),
+            Uri.file(projectAbsolutePath),
             {
                 forcenewwindow: openProjectInNewWindow ? CREATE_PROJECT.BUTTONS.NEW_WINDOW : false,
             }

--- a/packages/vscode-extension/src/startup/ShowSetupAccountWarning.ts
+++ b/packages/vscode-extension/src/startup/ShowSetupAccountWarning.ts
@@ -10,6 +10,7 @@ import { EXTENSION_INSTALLATION } from '../service/TranslationKeys';
 import { VSTranslationService } from '../service/VSTranslationService';
 
 const COMMAND_SETUP_ACCOUNT = 'suitecloud.setupaccount';
+const MANIFEST_FILE_FILENAME = "manifest.xml";
 const SRC_FOLDER_NAME = 'src';
 
 export default async function showSetupAccountWarningMessageIfNeeded(): Promise<void> {
@@ -23,6 +24,16 @@ export default async function showSetupAccountWarningMessageIfNeeded(): Promise<
 
 		const projectJsonAbsolutePath = path.join(projectAbsolutePath, ApplicationConstants.FILES.PROJECT_JSON);
 		if (!FileUtils.exists(projectJsonAbsolutePath)) {
+			await vscode.window.showTextDocument(
+				vscode.Uri.file(
+					path.join(
+						workspaceFolders[0].uri.fsPath,
+						SRC_FOLDER_NAME,
+						MANIFEST_FILE_FILENAME
+					)
+				)
+			);
+
 			const translationService = new VSTranslationService();
 			const runSetupAccount = await vscode.window.showWarningMessage(
 				translationService.getMessage(EXTENSION_INSTALLATION.PROJECT_STARTUP.MESSAGES.PROJECT_NEEDS_SETUP_ACCOUNT),


### PR DESCRIPTION
- PDPDVETOOL-4309: Project create requires an active file from current project
- PDPDEVTOOL-4310: setup account for new account