### PR TITLE
Bug fixed for PDPDEVTOOL-790: As a SuiteCloud Developer, I want to interact with the FILE:CREATE command exposed SDK in a interactive mode, so I can create Suite Script files and inject modules in to generate the template in CLI for Node.js

### DIFF
--- a/packages/node-cli/messages.json
+++ b/packages/node-cli/messages.json
@@ -33,7 +33,7 @@
 	"COMMAND_CREATEFILE_CHOOSE_SUITESCRIPT_TYPE": "What type of SuiteScript do you want to create?",
 	"COMMAND_CREATEFILE_ENTER_NAME": "Enter a name for the SuiteScript file.",
 	"COMMAND_CREATEFILE_MESSAGE_CREATING_FILE": "Creating SuiteScript file...",
-	"COMMAND_CREATEFILE_MESSAGE_SUITESCRIPT_FILE_CREATED": "The SuiteScript file was created successfully in {0}.",
+	"COMMAND_CREATEFILE_MESSAGE_SUITESCRIPT_FILE_CREATED": "The SuiteScript file was created successfully in {0}",
 	"COMMAND_CREATEFILE_MESSAGE_SUITESCRIPT_FILE_CREATED_WITH_MODULES": "The SuiteScript file was created successfully in {0}\nThe following modules were added to the script: {1}",
 	"COMMAND_CREATEFILE_SELECT_FOLDER": "Select the folder where you want to create the SuiteScript file",
 	"COMMAND_CREATEFILE_SELECT_SUITESCRIPT_MODULES": "Select the SuiteScript modules you want to add to the SuiteScript file",

--- a/packages/node-cli/messages.json
+++ b/packages/node-cli/messages.json
@@ -12,7 +12,7 @@
 	"ANSWERS_VALIDATION_MESSAGES_FIELD_HAS_SPACES": "This field cannot contain spaces.",
 	"ANSWERS_VALIDATION_MESSAGES_FIELD_HAS_XML_FORBIDDEN_CHARACTERS": "This field contains at least one of the following forbidden characters: <, >, &, ', or \".",
 	"ANSWERS_VALIDATION_MESSAGES_FIELD_NOT_LOWER_CASE": "The {0} field contains forbidden characters. Use only lowercase letters and numbers.",
-	"ANSWERS_VALIDATION_MESSAGES_FILE_ALREADY_EXISTS": "The SuiteScript file already exists in {0}",
+	"ANSWERS_VALIDATION_MESSAGES_FILE_ALREADY_EXISTS": "The SuiteScript file already exists.",
 	"ANSWERS_VALIDATION_MESSAGES_INVALID_EMAIL": "Invalid email address.",
 	"ANSWERS_VALIDATION_MESSAGES_MAX_LENGTH": "This field can only contain up to {0} characters.",
 	"ANSWERS_VALIDATION_MESSAGES_PROJECT_VERSION_FORMAT": "The project version must only contain digits and dots. Ensure it follows a pattern such as \"0.0.0\".",

--- a/packages/node-cli/src/commands/file/create/CreateFileAction.js
+++ b/packages/node-cli/src/commands/file/create/CreateFileAction.js
@@ -31,7 +31,9 @@ module.exports = class CreateFileAction extends BaseAction {
     preExecute(params) {
         params[COMMAND_OPTIONS.PROJECT] = CommandUtils.quoteString(this._projectFolder);
 
-        params[COMMAND_OPTIONS.PATH] = params.parentPath + params.name;
+        if (this._runInInteractiveMode) {
+            params[COMMAND_OPTIONS.PATH] = params.parentPath + params.name;
+        }
         if (!params[COMMAND_OPTIONS.PATH].endsWith(JS_EXTENSION)) {
             params[COMMAND_OPTIONS.PATH] = params[COMMAND_OPTIONS.PATH] + JS_EXTENSION;
         }

--- a/packages/node-cli/src/validation/InteractiveAnswersValidator.js
+++ b/packages/node-cli/src/validation/InteractiveAnswersValidator.js
@@ -180,7 +180,7 @@ module.exports = {
 		const fileSystemService = new FileSystemService();
 		return !fileSystemService.fileExists(path.join(parentFolderPath, filenameWithExtension))
 			? VALIDATION_RESULT_SUCCESS
-			: VALIDATION_RESULT_FAILURE(NodeTranslationService.getMessage(ANSWERS_VALIDATION_MESSAGES.FILE_ALREADY_EXISTS, parentFolderPath));
+			: VALIDATION_RESULT_FAILURE(NodeTranslationService.getMessage(ANSWERS_VALIDATION_MESSAGES.FILE_ALREADY_EXISTS));
 	}
 
 };


### PR DESCRIPTION
- PDPDEVTOOL-4307: The path shown after file creation is not OS independent (missed part 3 and update to validation message)
- PDPDEVTOOL-4314: Create file non-interactive error