### PR TITLE
feature/pdpdevtool-4189: vscode 'List Files' folder list cutoff

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -40,6 +40,11 @@
 				"category": "SuiteCloud"
 			},
 			{
+				"command": "suitecloud.createfile",
+				"title": "Create SuiteScript File",
+				"category": "SuiteCloud"
+			},
+			{
 				"command": "suitecloud.createproject",
 				"title": "Create Project...",
 				"category": "SuiteCloud"
@@ -87,11 +92,6 @@
 			{
 				"command": "suitecloud.uploadfile",
 				"title": "Upload File",
-				"category": "SuiteCloud"
-			},
-			{
-				"command": "suitecloud.createfile",
-				"title": "Create SuiteScript File",
 				"category": "SuiteCloud"
 			}
 		],

--- a/packages/vscode-extension/src/commands/BaseAction.ts
+++ b/packages/vscode-extension/src/commands/BaseAction.ts
@@ -6,13 +6,13 @@
 import { assert } from 'console';
 import * as vscode from 'vscode';
 import { Uri, window } from 'vscode';
-import { commandsInfoMap } from '../commandsMap';
 import SuiteCloudRunner from '../core/SuiteCloudRunner';
 import VSConsoleLogger from '../loggers/VSConsoleLogger';
 import MessageService from '../service/MessageService';
 import { ERRORS } from '../service/TranslationKeys';
 import { VSTranslationService } from '../service/VSTranslationService';
 import { CLIConfigurationService } from '../util/ExtensionUtil';
+import {commandsInfoMap, CommandsInfoMapType} from '../commandsMap';
 
 
 export default abstract class BaseAction {
@@ -27,8 +27,7 @@ export default abstract class BaseAction {
 
 	protected abstract execute(): Promise<void>;
 
-	constructor(commandName: string) {
-		assert(commandsInfoMap.hasOwnProperty(commandName), `Command name ${commandName} is not present in commandsMap`);
+	constructor(commandName: keyof CommandsInfoMapType) {
 		this.cliCommandName = commandsInfoMap[commandName].cliCommandName;
 		this.vscodeCommandName = commandsInfoMap[commandName].vscodeCommandName;
 		this.messageService = new MessageService(this.vscodeCommandName);

--- a/packages/vscode-extension/src/commands/ImportFiles.ts
+++ b/packages/vscode-extension/src/commands/ImportFiles.ts
@@ -83,7 +83,10 @@ export default class ImportFiles extends BaseAction {
 		const listFilesService = new ListFilesService(this.messageService, this.translationService, this.getRootProjectFolder());
 		listFilesService.setVsConsoleLogger(new VsErrorConsoleLogger(true, this.executionPath));
 		if (!this.isSelectedFromContextMenu) {
-			const fileCabinetFolders: FolderItem[] = await listFilesService.getListFolders();
+			const fileCabinetFolders: FolderItem[] | undefined = await listFilesService.getListFolders();
+			if (!fileCabinetFolders) {
+				return;
+			}
 			const selectedFolder: QuickPickItem | undefined = await listFilesService.selectFolder(fileCabinetFolders);
 			if (!selectedFolder) {
 				return;

--- a/packages/vscode-extension/src/commands/ListFiles.ts
+++ b/packages/vscode-extension/src/commands/ListFiles.ts
@@ -25,7 +25,7 @@ export default class ListFiles extends BaseAction {
 	protected async execute(): Promise<void> {
 		const listFilesService = new ListFilesService(this.messageService, this.translationService, this.getRootProjectFolder());
 		try {
-			let fileCabinetFolders: FolderItem[] | undefined= await listFilesService.getListFolders();
+			let fileCabinetFolders: FolderItem[] | undefined = await listFilesService.getListFolders();
 			if (!fileCabinetFolders) {
 				return;
 			}

--- a/packages/vscode-extension/src/commands/ListFiles.ts
+++ b/packages/vscode-extension/src/commands/ListFiles.ts
@@ -25,7 +25,10 @@ export default class ListFiles extends BaseAction {
 	protected async execute(): Promise<void> {
 		const listFilesService = new ListFilesService(this.messageService, this.translationService, this.getRootProjectFolder());
 		try {
-			let fileCabinetFolders: FolderItem[] = await listFilesService.getListFolders();
+			let fileCabinetFolders: FolderItem[] | undefined= await listFilesService.getListFolders();
+			if (!fileCabinetFolders) {
+				return;
+			}
 			const selectedFolder = await listFilesService.selectFolder(fileCabinetFolders);
 			if (selectedFolder) {
 				await this._listFiles(selectedFolder.label);

--- a/packages/vscode-extension/src/commands/ManageAccounts.ts
+++ b/packages/vscode-extension/src/commands/ManageAccounts.ts
@@ -11,7 +11,7 @@ import { MANAGE_ACCOUNTS, DISMISS } from '../service/TranslationKeys';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const COMMAND_NAME = 'manageaccounts';
+const COMMAND_NAME = 'setupaccount';
 
 enum UiOption {
 	new_authid,

--- a/packages/vscode-extension/src/commands/SetupAccount.ts
+++ b/packages/vscode-extension/src/commands/SetupAccount.ts
@@ -44,7 +44,7 @@ interface CancellationToken {
 	cancel?: (x: string) => void;
 }
 
-export default class ManageAccounts extends BaseAction {
+export default class SetupAccount extends BaseAction {
 	constructor() {
 		super(COMMAND_NAME);
 	}

--- a/packages/vscode-extension/src/commandsMap.ts
+++ b/packages/vscode-extension/src/commandsMap.ts
@@ -3,64 +3,92 @@
  ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 
-export const commandsInfoMap: {
-	[commandName: string]: {
-		cliCommandName: string;
-		vscodeCommandName: string;
-		// not really needed, just left here as an idea
-		vscodeShortName?: string;
-	};
-} = {
+export type CommandInfo = {
+	vscodeContributedCommand: string;
+	cliCommandName: string;
+	vscodeCommandName: string;
+	// not really needed, just left here as an idea
+	vscodeShortName?: string;
+};
+
+export type CommandsInfoMapType = {
+	adddependencies: CommandInfo;
+	createfile: CommandInfo;
+	createproject: CommandInfo;
+	deploy: CommandInfo;
+	importfiles: CommandInfo;
+	importfile: CommandInfo;
+	importobjects: CommandInfo;
+	listfiles: CommandInfo;
+	listobjects: CommandInfo;
+	setupaccount: CommandInfo;
+	updateobject: CommandInfo;
+	uploadfile: CommandInfo;
+};
+
+export const commandsInfoMap: CommandsInfoMapType = {
 	adddependencies: {
+		vscodeContributedCommand: 'suitecloud.adddependencies',
 		cliCommandName: 'project:adddependencies',
 		vscodeCommandName: 'Add Dependency References to the Manifest',
 		vscodeShortName: 'Add Dependencies',
 	},
+	createfile: {
+		vscodeContributedCommand: 'suitecloud.createfile',
+		cliCommandName: 'file:create',
+		vscodeCommandName: 'Create SuiteScript File',
+	},
 	createproject: {
+		vscodeContributedCommand: 'suitecloud.createproject',
 		cliCommandName: 'project:create',
 		vscodeCommandName: 'Create SuiteCloud Project...',
 		vscodeShortName: 'Create Project',
 	},
 	deploy: {
+		vscodeContributedCommand: 'suitecloud.deploy',
 		cliCommandName: 'project:deploy',
 		vscodeCommandName: 'Deploy Project...',
 		vscodeShortName: 'Deploy',
 	},
 	importfiles: {
+		vscodeContributedCommand: 'suitecloud.importfiles',
 		cliCommandName: 'file:import',
 		vscodeCommandName: 'Import Files',
 	},
 	importfile: {
+		vscodeContributedCommand: 'suitecloud.importfile',
 		cliCommandName: 'file:import',
 		vscodeCommandName: 'Import File',
 	},
 	importobjects: {
+		vscodeContributedCommand: 'suitecloud.importobjects',
 		cliCommandName: 'object:import',
 		vscodeCommandName: 'Import Objects',
 	},
 	listfiles: {
+		vscodeContributedCommand: 'suitecloud.listfiles',
 		cliCommandName: 'file:list',
 		vscodeCommandName: 'List Files',
 	},
 	listobjects: {
+		vscodeContributedCommand: 'suitecloud.listobjects',
 		cliCommandName: 'object:list',
 		vscodeCommandName: 'List Objects...',
 	},
-	uploadfile: {
-		cliCommandName: 'file:upload',
-		vscodeCommandName: 'Upload File',
-	},
-	createfile: {
-		cliCommandName: 'file:create',
-		vscodeCommandName: 'Create SuiteScript File',
-	},
-	manageaccounts: {
+	setupaccount: {
+		vscodeContributedCommand: 'suitecloud.setupaccount',
 		cliCommandName: 'account:setup',
 		vscodeCommandName: 'Set Up Account...',
 	},
 	updateobject: {
+		vscodeContributedCommand: 'suitecloud.updateobject',
 		cliCommandName: 'object:update',
 		vscodeCommandName: 'Update Single Object with Account Object',
 		vscodeShortName: 'Update Object',
+	},
+	uploadfile: {
+		vscodeContributedCommand: 'suitecloud.uploadfile',
+		cliCommandName: 'file:upload',
+		vscodeCommandName: 'Upload File',
 	},
 };

--- a/packages/vscode-extension/src/commandsMap.ts
+++ b/packages/vscode-extension/src/commandsMap.ts
@@ -4,7 +4,7 @@
  */
 
 export type CommandInfo = {
-	vscodeContributedCommand: string;
+	vscodeCommandId: string;
 	cliCommandName: string;
 	vscodeCommandName: string;
 	// not really needed, just left here as an idea
@@ -28,66 +28,66 @@ export type CommandsInfoMapType = {
 
 export const commandsInfoMap: CommandsInfoMapType = {
 	adddependencies: {
-		vscodeContributedCommand: 'suitecloud.adddependencies',
+		vscodeCommandId: 'suitecloud.adddependencies',
 		cliCommandName: 'project:adddependencies',
 		vscodeCommandName: 'Add Dependency References to the Manifest',
 		vscodeShortName: 'Add Dependencies',
 	},
 	createfile: {
-		vscodeContributedCommand: 'suitecloud.createfile',
+		vscodeCommandId: 'suitecloud.createfile',
 		cliCommandName: 'file:create',
 		vscodeCommandName: 'Create SuiteScript File',
 	},
 	createproject: {
-		vscodeContributedCommand: 'suitecloud.createproject',
+		vscodeCommandId: 'suitecloud.createproject',
 		cliCommandName: 'project:create',
 		vscodeCommandName: 'Create SuiteCloud Project...',
 		vscodeShortName: 'Create Project',
 	},
 	deploy: {
-		vscodeContributedCommand: 'suitecloud.deploy',
+		vscodeCommandId: 'suitecloud.deploy',
 		cliCommandName: 'project:deploy',
 		vscodeCommandName: 'Deploy Project...',
 		vscodeShortName: 'Deploy',
 	},
 	importfiles: {
-		vscodeContributedCommand: 'suitecloud.importfiles',
+		vscodeCommandId: 'suitecloud.importfiles',
 		cliCommandName: 'file:import',
 		vscodeCommandName: 'Import Files',
 	},
 	importfile: {
-		vscodeContributedCommand: 'suitecloud.importfile',
+		vscodeCommandId: 'suitecloud.importfile',
 		cliCommandName: 'file:import',
 		vscodeCommandName: 'Import File',
 	},
 	importobjects: {
-		vscodeContributedCommand: 'suitecloud.importobjects',
+		vscodeCommandId: 'suitecloud.importobjects',
 		cliCommandName: 'object:import',
 		vscodeCommandName: 'Import Objects',
 	},
 	listfiles: {
-		vscodeContributedCommand: 'suitecloud.listfiles',
+		vscodeCommandId: 'suitecloud.listfiles',
 		cliCommandName: 'file:list',
 		vscodeCommandName: 'List Files',
 	},
 	listobjects: {
-		vscodeContributedCommand: 'suitecloud.listobjects',
+		vscodeCommandId: 'suitecloud.listobjects',
 		cliCommandName: 'object:list',
 		vscodeCommandName: 'List Objects...',
 	},
 	setupaccount: {
-		vscodeContributedCommand: 'suitecloud.setupaccount',
+		vscodeCommandId: 'suitecloud.setupaccount',
 		cliCommandName: 'account:setup',
 		vscodeCommandName: 'Set Up Account...',
 	},
 	updateobject: {
-		vscodeContributedCommand: 'suitecloud.updateobject',
+		vscodeCommandId: 'suitecloud.updateobject',
 		cliCommandName: 'object:update',
 		vscodeCommandName: 'Update Single Object with Account Object',
 		vscodeShortName: 'Update Object',
 	},
 	uploadfile: {
-		vscodeContributedCommand: 'suitecloud.uploadfile',
+		vscodeCommandId: 'suitecloud.uploadfile',
 		cliCommandName: 'file:upload',
 		vscodeCommandName: 'Upload File',
 	},

--- a/packages/vscode-extension/src/service/ListFilesService.ts
+++ b/packages/vscode-extension/src/service/ListFilesService.ts
@@ -2,6 +2,7 @@
  ** Copyright (c) 2021 Oracle and/or its affiliates.  All rights reserved.
  ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { VSCODE_PLATFORM } from '../ApplicationConstants';
 import { getSdkPath } from '../core/sdksetup/SdkProperties';
@@ -16,8 +17,9 @@ import {
 	ExecutionEnvironmentContext,
 } from '../util/ExtensionUtil';
 import MessageService from './MessageService';
-import { COMMAND, IMPORT_FILES, LIST_FILES } from './TranslationKeys';
+import { COMMAND, EXTENSION_INSTALLATION, IMPORT_FILES, LIST_FILES } from './TranslationKeys';
 import { VSTranslationService } from './VSTranslationService';
+import { commandsInfoMap} from '../commandsMap';
 
 const LIST_FILES_COMMAND = {
 	OPTIONS: {
@@ -41,17 +43,31 @@ export default class ListFilesService {
 		this.executionPath = projectFolder;
 	}
 
-	public async getListFolders() {
+	public async getListFolders(): Promise<FolderItem[] | undefined> {
 		const executionEnvironmentContext = new ExecutionEnvironmentContext({
 			platform: VSCODE_PLATFORM,
 			platformVersion: vscode.version,
 		});
 
-		const listFoldersPromise = AccountFileCabinetService.getFileCabinetFolders(
-			getSdkPath(),
-			executionEnvironmentContext,
-			AuthenticationUtils.getProjectDefaultAuthId(this.executionPath)
-		);
+		let defaultAuthId: string | undefined;
+		try {
+			defaultAuthId = AuthenticationUtils.getProjectDefaultAuthId(this.executionPath);
+		} catch (error) {
+			defaultAuthId = undefined;
+		}
+
+		if (!defaultAuthId) {
+			const runSetupAccount = await vscode.window.showWarningMessage(
+				this.translationService.getMessage(EXTENSION_INSTALLATION.PROJECT_STARTUP.MESSAGES.PROJECT_NEEDS_SETUP_ACCOUNT),
+				this.translationService.getMessage(EXTENSION_INSTALLATION.PROJECT_STARTUP.BUTTONS.RUN_SUITECLOUD_SETUP_ACCOUNT)
+			);
+			if (runSetupAccount) {
+				vscode.commands.executeCommand(commandsInfoMap.setupaccount.vscodeContributedCommand);
+			}
+			return;
+		}
+
+		const listFoldersPromise = AccountFileCabinetService.getFileCabinetFolders(getSdkPath(), executionEnvironmentContext, defaultAuthId);
 		const statusBarMessage = this.translationService.getMessage(LIST_FILES.LOADING_FOLDERS);
 		this.messageService.showStatusBarMessage(statusBarMessage, listFoldersPromise);
 
@@ -80,12 +96,13 @@ export default class ListFilesService {
 		return vscode.window.showQuickPick(
 			folders.map((folder: FolderItem) => {
 				const description = folder.isRestricted ? this.translationService.getMessage(LIST_FILES.RESTRICTED_FOLDER) : '';
-				return { label: folder.path, description };
+				return { label: folder.path, description, detail: path.basename(folder.path) };
 			}),
 			{
 				ignoreFocusOut: true,
 				placeHolder: this.translationService.getMessage(LIST_FILES.SELECT_FOLDER),
 				canPickMany: false,
+				onDidSelectItem: (item: vscode.QuickPickItem) => vscode.window.setStatusBarMessage(item.label, 5000),
 			}
 		);
 	}

--- a/packages/vscode-extension/src/service/ListFilesService.ts
+++ b/packages/vscode-extension/src/service/ListFilesService.ts
@@ -27,8 +27,6 @@ const LIST_FILES_COMMAND = {
 	},
 };
 
-const SUITECLOUD_COMMAND_NAME = 'file:list';
-const COMMAND_NAME_LIST_FILES = 'listfiles';
 const CONSOLE_LOGGER_ERROR = 'vsConsole Logger not initialized';
 
 export default class ListFilesService {
@@ -137,7 +135,7 @@ export default class ListFilesService {
 		listfilesOptions[LIST_FILES_COMMAND.OPTIONS.FOLDER] = selectedFolder;
 
 		const commandActionPromise = this.listFilesCommand(listfilesOptions);
-		const commandMessage = this.translationService.getMessage(COMMAND.TRIGGERED, COMMAND_NAME_LIST_FILES);
+		const commandMessage = this.translationService.getMessage(COMMAND.TRIGGERED, commandsInfoMap.listfiles.vscodeCommandName);
 		const statusBarMessage = this.translationService.getMessage(LIST_FILES.LISTING);
 		this.messageService.showInformationMessage(commandMessage, statusBarMessage, commandActionPromise);
 
@@ -154,7 +152,7 @@ export default class ListFilesService {
 			throw Error(CONSOLE_LOGGER_ERROR);
 		}
 		const suiteCloudRunnerRunResult = await new SuiteCloudRunner(this.vsConsoleLogger, this.executionPath).run({
-			commandName: SUITECLOUD_COMMAND_NAME,
+			commandName: commandsInfoMap.listfiles.cliCommandName,
 			arguments: listFilesOption,
 		});
 

--- a/packages/vscode-extension/src/service/ListFilesService.ts
+++ b/packages/vscode-extension/src/service/ListFilesService.ts
@@ -60,7 +60,7 @@ export default class ListFilesService {
 				this.translationService.getMessage(EXTENSION_INSTALLATION.PROJECT_STARTUP.BUTTONS.RUN_SUITECLOUD_SETUP_ACCOUNT)
 			);
 			if (runSetupAccount) {
-				vscode.commands.executeCommand(commandsInfoMap.setupaccount.vscodeContributedCommand);
+				vscode.commands.executeCommand(commandsInfoMap.setupaccount.vscodeCommandId);
 			}
 			return;
 		}

--- a/packages/vscode-extension/src/startup/ShowSetupAccountWarning.ts
+++ b/packages/vscode-extension/src/startup/ShowSetupAccountWarning.ts
@@ -8,8 +8,8 @@ import * as vscode from 'vscode';
 import { ApplicationConstants, FileUtils, ProjectInfoService } from '../util/ExtensionUtil';
 import { EXTENSION_INSTALLATION } from '../service/TranslationKeys';
 import { VSTranslationService } from '../service/VSTranslationService';
+import { commandsInfoMap } from '../commandsMap';
 
-const COMMAND_SETUP_ACCOUNT = 'suitecloud.setupaccount';
 const MANIFEST_FILE_FILENAME = "manifest.xml";
 const SRC_FOLDER_NAME = 'src';
 
@@ -40,7 +40,7 @@ export default async function showSetupAccountWarningMessageIfNeeded(): Promise<
 				translationService.getMessage(EXTENSION_INSTALLATION.PROJECT_STARTUP.BUTTONS.RUN_SUITECLOUD_SETUP_ACCOUNT),
 			);
 			if (runSetupAccount) {
-				vscode.commands.executeCommand(COMMAND_SETUP_ACCOUNT);
+				vscode.commands.executeCommand(commandsInfoMap.setupaccount.vscodeContributedCommand);
 			}
 		}
 	}

--- a/packages/vscode-extension/src/startup/ShowSetupAccountWarning.ts
+++ b/packages/vscode-extension/src/startup/ShowSetupAccountWarning.ts
@@ -40,7 +40,7 @@ export default async function showSetupAccountWarningMessageIfNeeded(): Promise<
 				translationService.getMessage(EXTENSION_INSTALLATION.PROJECT_STARTUP.BUTTONS.RUN_SUITECLOUD_SETUP_ACCOUNT),
 			);
 			if (runSetupAccount) {
-				vscode.commands.executeCommand(commandsInfoMap.setupaccount.vscodeContributedCommand);
+				vscode.commands.executeCommand(commandsInfoMap.setupaccount.vscodeCommandId);
 			}
 		}
 	}

--- a/packages/vscode-extension/src/suitecloud.ts
+++ b/packages/vscode-extension/src/suitecloud.ts
@@ -15,7 +15,7 @@ import ImportFiles from './commands/ImportFiles';
 import ImportObjects from './commands/ImportObjects';
 import ListFiles from './commands/ListFiles';
 import ListObjects from './commands/ListObjects';
-import ManageAccounts from './commands/ManageAccounts';
+import SetupAccount from './commands/SetupAccount';
 import UpdateObject from './commands/UpdateObject';
 import UploadFile from './commands/UploadFile';
 import { installIfNeeded } from './core/sdksetup/SdkServices';
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		register('suitecloud.importobjects', new ImportObjects()),
 		register('suitecloud.listfiles', new ListFiles()),
 		register('suitecloud.listobjects', new ListObjects()),
-		register('suitecloud.setupaccount', new ManageAccounts()),
+		register('suitecloud.setupaccount', new SetupAccount()),
 		register('suitecloud.updateobject', new UpdateObject()),
 		register('suitecloud.uploadfile', new UploadFile())
 	);


### PR DESCRIPTION
Improve visualization of the available folders list of the FileCabinet in vscode 'List Files' command.
Refactor of commandsMap
Fix minor output references to command names ListFilesService
Add "Setup Account" link when no defaultAuthId is available in the project when triggering 'List Files'.

Closes PDPDEVTOOL-4189