### PR TITLE
bugfix/pdpdevtool-4409: Listed files info in vscode 'Files Import'

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -134,18 +134,23 @@
 		"menus": {
 			"explorer/context": [
 				{
-					"when": "!explorerResourceIsFolder && resource =~ //FileCabinet/(SuiteScripts|Templates/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)/.+$/",
-					"command": "suitecloud.updatefile",
+					"when": "explorerResourceIsFolder && resource =~ //FileCabinet/(SuiteApps/[a-z0-9]+.[a-z0-9]+.[a-z0-9]+|SuiteScripts)(/.*)*$/",
+					"command": "suitecloud.createfile",
+					"group": "suitecloud@1"
+				},
+				{
+					"when": "explorerResourceIsFolder && resource =~ //FileCabinet/(SuiteScripts|Templates/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)(/.*)*$/",
+					"command": "suitecloud.importfiles",
 					"group": "suitecloud@1"
 				},
 				{
 					"when": "resource =~ //Objects(/.+)*$/",
 					"command": "suitecloud.importobjects",
-					"group": "suitecloud@2"
+					"group": "suitecloud@1"
 				},
 				{
-					"when": "explorerResourceIsFolder && resource =~ //FileCabinet/(SuiteApps/[a-z0-9]+.[a-z0-9]+.[a-z0-9]+|SuiteScripts)(/.*)*$/",
-					"command": "suitecloud.createfile",
+					"when": "!explorerResourceIsFolder && resource =~ //FileCabinet/(SuiteScripts|Templates/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)/.+$/",
+					"command": "suitecloud.updatefile",
 					"group": "suitecloud@1"
 				}
 			]

--- a/packages/vscode-extension/src/commands/FileImportCommon.ts
+++ b/packages/vscode-extension/src/commands/FileImportCommon.ts
@@ -50,7 +50,7 @@ export default abstract class FileImportCommon extends BaseAction {
 		}
 
 		const override = await window.showQuickPick(
-			[this.translationService.getMessage(ANSWERS.YES), this.translationService.getMessage(ANSWERS.NO)],
+			[this.translationService.getMessage(ANSWERS.CONTINUE), this.translationService.getMessage(ANSWERS.CANCEL)],
 			{
 				placeHolder:
 					selectedFilesPaths.length > 1
@@ -63,7 +63,7 @@ export default abstract class FileImportCommon extends BaseAction {
 		if (!override) {
 			return;
 		}
-		if (override === this.translationService.getMessage(ANSWERS.NO)) {
+		if (override === this.translationService.getMessage(ANSWERS.CANCEL)) {
 			this.messageService.showInformationMessage(this.translationService.getMessage(IMPORT_FILES.PROCESS_CANCELED));
 			return;
 		}

--- a/packages/vscode-extension/src/service/ListFilesService.ts
+++ b/packages/vscode-extension/src/service/ListFilesService.ts
@@ -77,13 +77,15 @@ export default class ListFilesService {
 	public async selectFiles(files: string[]): Promise<vscode.QuickPickItem[] | undefined> {
 		let finish: boolean = false;
 		let message = this.translationService.getMessage(IMPORT_FILES.QUESTIONS.SELECT_FILES);
+		const filesChoices = files.map((file) => ({ label: file, detail: path.basename(file) }));
 		while (!finish) {
 			const selectedFiles = await vscode.window.showQuickPick(
-				files.map((file) => ({ label: file })),
+				filesChoices,
 				{
 					ignoreFocusOut: true,
 					placeHolder: message,
 					canPickMany: true,
+					onDidSelectItem: (item: vscode.QuickPickItem) => vscode.window.setStatusBarMessage(item.label, 5000),
 				}
 			);
 			if (!selectedFiles || selectedFiles.length > 0) {


### PR DESCRIPTION
Fixes:
- PDPDEVTOOL-4405: Overwrite confirmation answers 
- PDPDEVTOOL-4409: listed files info shown in dropdown

It also puts back the `Import Files` to context menu.
