### PR TITLE
bugfix/pdpdevtool 4438: prepare versions before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oracle/suitecloud-sdk",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"license": "UPL-1.0",
 	"private": true,
 	"devDependencies": {

--- a/packages/unit-testing/package.json
+++ b/packages/unit-testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oracle/suitecloud-unit-testing",
-	"version": "1.1.4",
+	"version": "1.1.3",
 	"license": "UPL-1.0",
 	"repository": "https://github.com/oracle/netsuite-suitecloud-sdk/tree/master/packages/unit-testing",
 	"bugs": {


### PR DESCRIPTION
Update unit-testing version to match the one in master branch (will be automatically updated by 'lerna publish').
Update root version to match future node-cli version (this one won't be updated by 'lerna publish').