### PR TITLE
Remove vscode-extension from npm workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"private": true,
 	"workspaces": [
 		"packages/node-cli",
-		"packages/unit-testing",
-		"packages/vscode-extension"
+		"packages/unit-testing"
 	]
 }


### PR DESCRIPTION
Remove vscode-extension from npm workspaces. This need to be done because vsce doesn't work well with npm workspaces.