### PR TITLE
Set vscode engine version to ^1.91.1

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -23,7 +23,7 @@
 		"**/*.vsix"
 	],
 	"engines": {
-		"vscode": "1.91.1"
+		"vscode": "^1.91.1"
 	},
 	"categories": [
 		"Other"


### PR DESCRIPTION
Set vscode engine version to ^1.91.1 to make extension compatible with newer versions