### PR TITLE
bugfix/pdpdevtool-5818: vscode compare with account file

### DIFF
--- a/packages/vscode-extension/src/commands/SetupAccount.ts
+++ b/packages/vscode-extension/src/commands/SetupAccount.ts
@@ -302,7 +302,7 @@ export default class SetupAccount extends BaseAction {
 			authid: authId,
 			account: accountId,
 			certificateid: certificateId,
-			privatekeypath: privateKeyFilePath[0].fsPath,
+			privatekeypath: `"${privateKeyFilePath[0].fsPath}"`,
 			domain: url,
 		};
 


### PR DESCRIPTION
Fix compare to account file in vscode-extension, issue #841 
Fix problem with privatekeypath containing blank spaces in vscode.
