### PR TITLE
Bugfix/PDPDEVTOOL-6004: [vscode] Removed the "option --authid must have a value" error message when creating new project

### DIFF
--- a/packages/vscode-extension/src/commands/BaseAction.ts
+++ b/packages/vscode-extension/src/commands/BaseAction.ts
@@ -54,12 +54,11 @@ export default abstract class BaseAction {
 
 			if (this.commandMetadata.isSetupRequired) {
 				const defaultAuthId = this.getDefaultAuthId();
-				if (defaultAuthId !== '') {
-					await this.checkAndRefreshAuthorizationIfNeeded(defaultAuthId);
-				} else {
+				if (!defaultAuthId) {
 					showSetupAccountWarningMessage();
 					return;
 				}
+				await this.checkAndRefreshAuthorizationIfNeeded(defaultAuthId);
 			}
 
 			return this.execute();


### PR DESCRIPTION
## CHANGES
Fixed Error Message thrown when `project.json` doesn't exist in project and user  attempts to use a command that requires authentication (without signing up first),
<br />
Previously, the following error message appeared:
 - `{project_name}: Option -authid must have a value.`

Now the standard error message appears
 - `No account has been set up for this project. Click "SuiteCloud: Set Up Account" to link your project to your account.`