### PR TITLE
Fix compatibility and copyright date

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please consult the [security guide](./SECURITY.md) for our responsible security 
 
 
 ## License
-Copyright (c) 2022, 2023, 2024, 2025 Oracle and/or its affiliates The Universal Permissive License (UPL), Version 1.0.
+Copyright (c) 2019, 2023 Oracle and/or its affiliates The Universal Permissive License (UPL), Version 1.0.
 
 By installing SuiteCloud CLI for Node.js, you are accepting the installation of the SuiteCloud SDK dependency under the [Oracle Free Use Terms and Conditions](https://www.oracle.com/downloads/licenses/oracle-free-license.html) license.
 

--- a/packages/node-cli/README.md
+++ b/packages/node-cli/README.md
@@ -26,7 +26,7 @@ The following table shows the CLI versions currently available in NPM.
 | CLI Versions Available in NPM | Available Since | Compatible NetSuite Version |
 |:-----------------------------:|:---------------:|:---------------------------:|
 | 3.0.X | 2025.1 | 2024.2 and 2025.1 |
-| 2.0.X | 2024.2 | 2024.1 and 2024.2 |
+| 2.0.X | 2024.2 | 2024.2 and 2025.1 |
 
 ## Installation
 Since CLI for Node.js is a development tool, use a global instance to install it by running the following command:
@@ -101,6 +101,6 @@ To read the 2025.1 NetSuite's release notes and documentation, check the followi
 SuiteCloud CLI for Node.js is an open source project. Pull Requests are currently not being accepted. See [Contributing](/CONTRIBUTING.md) for details.
 
 ## [License](/LICENSE.txt)
-Copyright (c) 2022, 2023, 2024, 2025 Oracle and/or its affiliates The Universal Permissive License (UPL), Version 1.0.
+Copyright (c) 2019, 2023 Oracle and/or its affiliates The Universal Permissive License (UPL), Version 1.0.
 
 By installing SuiteCloud CLI for Node.js, you are accepting the installation of the SuiteCloud SDK dependency under the [Oracle Free Use Terms and Conditions](https://www.oracle.com/downloads/licenses/oracle-free-license.html) license.

--- a/packages/unit-testing/README.md
+++ b/packages/unit-testing/README.md
@@ -325,4 +325,4 @@ describe('Sample test with user defined http module stub', () => {
 Suitecloud Unit Testing is an open source project. Pull requests are currently not being accepted. See [Contributing](/CONTRIBUTING.md) for details.
 
 ## [License](/LICENSE.txt)
-Copyright (c) 2023, 2024, 2025 Oracle and/or its affiliates The Universal Permissive License (UPL), Version 1.0.
+Copyright (c) 2019, 2023 Oracle and/or its affiliates The Universal Permissive License (UPL), Version 1.0.

--- a/packages/vscode-extension/LICENSE
+++ b/packages/vscode-extension/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024, Oracle and/or its affiliates.  All rights reserved.
+Copyright (c) 2021, 2023 Oracle and/or its affiliates.  All rights reserved.
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -26,7 +26,7 @@ The following table shows the extension versions currently available in the Mark
 | Extension Versions Available in the Marketplace | Available Since | Compatible NetSuite Version |
 |:-----------------------------------------------:|:---------------:|:---------------------------:|
 | 3.0.0 | 2025.1 | 2024.2 and 2025.1 |
-| 2.0.X | 2024.2 | 2024.1 and 2024.2 |
+| 2.0.X | 2024.2 | 2024.2 and 2025.1 |
 
 ## Installing SuiteCloud Extension for Visual Studio Code
 To install SuiteCloud Extension for Visual Studio Code, follow these steps:
@@ -124,6 +124,6 @@ To read the 2025.1 NetSuite's release notes and documentation, check the followi
 SuiteCloud Extension for Visual Studio Code is an open source project. Pull Requests are currently not being accepted. See [Contributing](/CONTRIBUTING.md) for details.
 
 ## License
-Copyright (c) 2022, 2023, 2024, 2025 Oracle and/or its affiliates The Universal Permissive License (UPL), version 1.0. See [License](/LICENSE.txt) for details.
+Copyright (c) 2021, 2023 Oracle and/or its affiliates The Universal Permissive License (UPL), version 1.0. See [License](/LICENSE.txt) for details.
 
 By installing SuiteCloud Extension for Visual Studio Code, you are accepting the installation of the SuiteCloud SDK dependency under the [Oracle Free Use Terms and Conditions](https://www.oracle.com/downloads/licenses/oracle-free-license.html) license.


### PR DESCRIPTION
Fixed compatibility issues
Fixed copyright year to show initial year and last modification year. VS Code related files now show 2021, 2023. Rest of the files now show 2019, 2023.