### PR TITLE
bugfix/PDPDEVTOOL-6254: fix wrong vsLogger method call

### DIFF
--- a/packages/vscode-extension/src/startup/DevAssistConfiguration.ts
+++ b/packages/vscode-extension/src/startup/DevAssistConfiguration.ts
@@ -64,7 +64,7 @@ export const startDevAssistProxyIfEnabled = async (devAssistStatusBar: vscode.St
         }
     } else {
         // TODO: We might want to propose to configure and enable service
-        vsLogger.log(translationService.getMessage(DEVASSIST_SERVICE.IS_DISABLED.OUTPUT));
+        vsLogger.info(translationService.getMessage(DEVASSIST_SERVICE.IS_DISABLED.OUTPUT));
     }
     // add extra line to differenciate logs
     vsLogger.info('');

--- a/packages/vscode-extension/src/types/JavascriptNodeCli.d.ts
+++ b/packages/vscode-extension/src/types/JavascriptNodeCli.d.ts
@@ -19,6 +19,16 @@ export type SdkOperationResult<T> = {
 	isSuccess(): false;
 }
 
+export interface ConsoleLoggerInterface {
+	info(message: string): void;
+	result(message: string): void;
+	warning(message: string): void;
+	error(message: string): void;
+}
+export interface ConsoleLoggerConstructor {
+	new(): ConsoleLoggerInterface
+}
+
 export interface ExecutionEnvironmentContextInterface {
 	getPlatform(): string;
 	getPlatformVersion(): string;

--- a/packages/vscode-extension/src/util/ExtensionUtil.ts
+++ b/packages/vscode-extension/src/util/ExtensionUtil.ts
@@ -3,7 +3,7 @@
  ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 import type { ActionResult, AuthListData } from '../types/ActionResult';
-import type { SdkOperationResult, SuiteCloudAuthProxyServiceConstructor, ExecutionEnvironmentContextConstructor, ExecutionEnvironmentContextInterface } from '../types/JavascriptNodeCli'
+import type { ConsoleLoggerConstructor, ExecutionEnvironmentContextConstructor, ExecutionEnvironmentContextInterface, SdkOperationResult, SuiteCloudAuthProxyServiceConstructor } from '../types/JavascriptNodeCli';
 
 
 export const SUITESCRIPT_TYPES: { id: string; name: string }[] = require('@oracle/suitecloud-cli/src/metadata/SuiteScriptTypesMetadata');
@@ -29,7 +29,7 @@ export const CommandActionExecutor = require('@oracle/suitecloud-cli/src/core/Co
 export const CommandsMetadataService = require('@oracle/suitecloud-cli/src/core/CommandsMetadataService');
 export const CommandOptionsValidator = require('@oracle/suitecloud-cli/src/core/CommandOptionsValidator');
 export const CLIConfigurationService = require('@oracle/suitecloud-cli/src/core/extensibility/CLIConfigurationService');
-export const ConsoleLogger = require('@oracle/suitecloud-cli/src/loggers/ConsoleLogger');
+export const ConsoleLogger: ConsoleLoggerConstructor = require('@oracle/suitecloud-cli/src/loggers/ConsoleLogger');
 export const AccountFileCabinetService = require('@oracle/suitecloud-cli/src/services/AccountFileCabinetService');
 export const EnvironmentInformationService = require('@oracle/suitecloud-cli/src/services/EnvironmentInformationService');
 export const FileCabinetService = require('@oracle/suitecloud-cli/src/services/FileCabinetService');


### PR DESCRIPTION
fix wrong vsLogger method call on DevAssistConfiguration.ts
add type for node-cli ConsoleLogger to avoid future mistakes