### PR TITLE
Add .claude-plugin/plugin.json to packages/agent-skills

### DIFF
--- a/packages/agent-skills/.claude-plugin/plugin.json
+++ b/packages/agent-skills/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "netsuite-suitecloud",
+  "description": "NetSuite agent skills from Oracle — SDF/UIF authoring guidance, secure-coding and SuiteScript references, plus runtime guidance for the NetSuite AI Service Connector.",
+  "version": "1.1.0",
+  "author": { "name": "Oracle NetSuite" },
+  "skills": [
+    "./netsuite-ai-connector-instructions",
+    "./netsuite-sdf-roles-and-permissions",
+    "./netsuite-uif-spa-reference",
+    "./netsuite-owasp-secure-coding",
+    "./netsuite-sdf-project-documentation",
+    "./netsuite-suitescript-records-reference",
+    "./netsuite-suitescript-upgrade"
+  ]
+}


### PR DESCRIPTION
## What

Adds a plugin manifest at `packages/agent-skills/.claude-plugin/plugin.json` declaring the agent-skills bundle and its seven skills.

## Why

`packages/agent-skills` is distributed through the Claude Code plugin marketplace as a `git-subdir` source. The marketplace tooling validates an external plugin by resolving the source and looking for a literal manifest (`.claude-plugin/plugin.json` or `plugin.json`) at the plugin root. There isn't one today, so automated validation and SHA updates can't process the entry, and it has stayed pinned to an older commit.

Adding this manifest:
- lets the marketplace validate and update the plugin automatically going forward, and
- ensures all seven skills currently in `packages/agent-skills/` are picked up (the three originally published plus `netsuite-owasp-secure-coding`, `netsuite-sdf-project-documentation`, `netsuite-suitescript-records-reference`, and `netsuite-suitescript-upgrade`).

## Validation

`claude plugin validate packages/agent-skills` passes with this manifest in place.

The `version` is a suggested value — please set it to whatever matches your release conventions.