### PR TITLE
Add N/pgp unit testing stubs (issue #943)

### DIFF
--- a/packages/unit-testing/jest-configuration/SuiteCloudJestConfiguration.js
+++ b/packages/unit-testing/jest-configuration/SuiteCloudJestConfiguration.js
@@ -278,6 +278,38 @@ const CORE_STUBS = [
 		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/log/log.js`,
 	},
 	{
+		module: 'N/pgp',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/pgp.js`,
+	},
+	{
+		module: 'N/pgp/config',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/Config.js`,
+	},
+	{
+		module: 'N/pgp/key',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/Key.js`,
+	},
+	{
+		module: 'N/pgp/keyId',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/KeyId.js`,
+	},
+	{
+		module: 'N/pgp/message',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/Message.js`,
+	},
+	{
+		module: 'N/pgp/messageData',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/MessageData.js`,
+	},
+	{
+		module: 'N/pgp/verification',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/Verification.js`,
+	},
+	{
+		module: 'N/pgp/verificationSignature',
+		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/pgp/VerificationSignature.js`,
+	},
+	{
 		module: 'N/piremoval',
 		path: `<rootDir>/node_modules/${CORE_STUBS_PATH}/piremoval/piremoval.js`,
 	},

--- a/packages/unit-testing/stubs/pgp/Config.js
+++ b/packages/unit-testing/stubs/pgp/Config.js
@@ -1,0 +1,49 @@
+define([], function () {
+    /**
+     * Returns a new instance of pgp.Config used to configure PGP operations.
+     *
+	 * @class Config
+	 * @classdesc General configuration options that can be used for message decryption.
+	 * @constructor
+     * @protected
+     *
+     * @since 2022.2
+     */
+    function Config() {
+        /**
+         * Allows messages that do not include integrity protection.
+         * @name Config#allowMessagesWithoutIntegrityProtection
+         * @type {boolean}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.allowMessagesWithoutIntegrityProtection = undefined;
+
+        /**
+         * Enables decryption that is not secured with signing keys.
+         * @name Config#allowInsecureDecryptionWithSigningKeys
+         * @type {boolean}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.allowInsecureDecryptionWithSigningKeys = undefined;
+
+        /**
+         * Allows relaxed signature parsing for configuration objects.
+         * @name Config#useRelaxedSignatureParsing
+         * @type {boolean}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.useRelaxedSignatureParsing = undefined;
+
+    }
+
+    return new Config();
+});

--- a/packages/unit-testing/stubs/pgp/Key.js
+++ b/packages/unit-testing/stubs/pgp/Key.js
@@ -1,0 +1,17 @@
+define([], function () {
+    /**
+     * Returns a new instance of pgp.Key, which stores multiple cryptographic keys and metadata.
+	 * You can use this object in the Message.decrypt(options) and MessageData.encrypt(options) methods.
+     *
+     * @class Key
+     * @classdesc A cryptographic key and its metadata.
+     * @constructor
+     * @protected
+     *
+     * @since 2022.2
+     */
+    function Key() {
+    }
+
+    return new Key();
+});

--- a/packages/unit-testing/stubs/pgp/KeyId.js
+++ b/packages/unit-testing/stubs/pgp/KeyId.js
@@ -1,0 +1,26 @@
+define([], function () {
+    /**
+     * Returns a new instance of pgp.KeyId, which stores an octet scalar that identifies a (sub)key. This object is used for verification signatures.
+     *
+     * @class KeyId
+     * @classdesc Encapsulation of a PGP key identifier.
+     * @constructor
+     * @protected
+     *
+     * @since 2022.2
+     */
+    function KeyId() {
+        /**
+         * Returns the key ID value as a hexadecimal string.
+         * @restriction Server SuiteScript only
+         * @governance none
+         * @return {string}
+         *
+         * @since 2022.2
+         */
+        this.asHex = function () { };
+
+    }
+
+    return new KeyId();
+});

--- a/packages/unit-testing/stubs/pgp/Message.js
+++ b/packages/unit-testing/stubs/pgp/Message.js
@@ -1,0 +1,72 @@
+define(['./Config', './Key', './MessageData', './Verification'], function (Config, Key, MessageData, Verification) {
+    /**
+     * Returns a new instance of pgp.Message used to store processed PGP data.
+     *
+     * @class Message
+     * @classdesc Encapsulation of processed PGP data responsible for enabling message serialization and providing a set of single-step processors to covert to a readable message.
+     * @constructor
+	 * @protected
+     *
+     * @since 2022.2
+     */
+    function Message() {
+        /**
+         * Message type that specifies how the PGP message is processed.
+         * @name Message#type
+         * @type {boolean}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.type = undefined;
+
+        /**
+         * Converts a message to ASCII armored format.
+         * @restriction Server SuiteScript only
+         * @governance none
+         * @return {string}
+         *
+         * @since 2022.2
+         */
+        this.asArmored = function () { };
+
+        /**
+         * Decrypts a message and optionally verifies the signatures.
+         * @restriction Server SuiteScript only
+         * @governance none
+         *
+         * @param {Object} options
+         * @param {Key|Key[]} options.decryptionKeys One or more keys used to attempt message decryption.
+         * @param {Key|Key[]} [options.verificationKeys] Zero or more keys used to attempt message signature verification.
+         * @param {Verification} [options.verification] An empty verification object. If you provide a value for this parameter, the verification results will be flushed instead of throwing an error for invalid signature. Default value = null.
+         * @param {boolean} [options.supressVerificationErrors] If set to true, the verification errors will not be thrown. This value is implicitly set to true when the verification parameter is provided. Default value = false.
+         * @param {Config} [options.config] PGP configuration options used during decryption.
+         * @return {MessageData}
+         *
+		 * @throws {SuiteScriptError} PGP_EXPECTED_ENCRYPTED_MESSAGE if the message is not encrypted.
+		 * @throws {SuiteScriptError} PGP_NO_MATCHING_DECRYPTION_KEY_ANALYSIS_1 if no matching decryption key was found.
+		 * @throws {SuiteScriptError} PGP_MESSAGE_IS_NOT_INTEGRITY_PROTECTED if the message is not integrity protected.
+		 * @throws {SuiteScriptError} PGP_INTEGRITY_VERIFICATION_FAILED if the message is corrupted.
+		 * @throws {SuiteScriptError} PGP_VERIFICATION_FAILED_NO_SIGNATURE if the message is not signed, but verification keys were provided.
+		 * @throws {SuiteScriptError} PGP_VERIFICATION_FAILED_1 if none of the signatures could be verified using the provided verification keys.
+		 *
+         * @since 2022.2
+         */
+        this.decrypt = function (options) { };
+
+        /**
+         * Converts the PGP message to message data without processing. Works only if the message is not encrypted.
+         * @restriction Server SuiteScript only
+         * @governance none
+         * @return {MessageData}
+		 *
+		 * @throws {SuiteScriptError} PGP_EXPECTED_UNENCRYPTED_MESSAGE The message is encrypted.
+         *
+         * @since 2022.2
+         */
+        this.toMessageData = function () { };
+    }
+
+    return new Message();
+});

--- a/packages/unit-testing/stubs/pgp/MessageData.js
+++ b/packages/unit-testing/stubs/pgp/MessageData.js
@@ -1,0 +1,86 @@
+define(['./Message'], function (Message) {
+    /**
+     * Returns a new instance of pgp.MessageData used to hold PGP message data.
+     *
+     * @class MessageData
+     * @classdesc Stores message data with metadata, provides a set of single-step processors for various PGP use cases.
+     * @constructor
+     * @protected
+     *
+     * @since 2022.2
+     */
+    function MessageData() {
+        /**
+         * The file name associated with the message data.
+         * @name MessageData#filename
+         * @type {string}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.filename = undefined;
+
+        /**
+         * The date of a message or modification date of the file.
+         * @name MessageData#date
+         * @type {Date}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.date = undefined;
+
+        /**
+         * Literal data packet type.
+         * @name MessageData#format
+         * @type {string} Use values from the pgp.Format enum
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.format = undefined;
+
+        /**
+         * Creates an encrypted message that is optionally signed.
+         * @restriction Server SuiteScript only
+         * @governance none
+         *
+         * @param {Object} options
+         * @param {Key|Key[]} options.encryptionKeys One or more keys used to encrypt a message. If a key contains multiple valid encryption (sub)keys, the most recent key added will be used.
+         * @param {Key|Key[]} [options.signingKeys] Zero or more keys used for signing. If a key contains multiple valid signing (sub)keys, the most recent key added will be used.
+         * @param {string} [options.compressionAlgorithm] Compression algorithm to use. Use values from the pgp.CompressionAlgorithm enum.
+         * @return {Message}
+		 *
+		 * @throws {SuiteScriptError} PGP_NO_ENCRYPTION_KEY_FOUND_IN_KEY_PARAM_1 when no valid encryption (sub)key was found in one of the provided keys.
+		 * @throws {SuiteScriptError} PGP_NO_SIGNING_KEY_FOUND_IN_KEY_PARAM_1 when no valid signing (sub)key was found in one of the provided keys.
+         *
+         * @since 2022.2
+         */
+        this.encrypt = function (options) { };
+
+        /**
+         * Extracts the contents of the message as text.
+         * @restriction Server SuiteScript only
+         * @governance none
+         * @return {string}
+         *
+         * @since 2022.2
+         */
+        this.getText = function () { };
+
+        /**
+         * Creates a message with no signature, compression, or encryption.
+         * @restriction Server SuiteScript only
+         * @governance none
+         * @return {Message}
+         *
+         * @since 2022.2
+         */
+        this.toMessage = function () { };
+    }
+
+    return new MessageData();
+});

--- a/packages/unit-testing/stubs/pgp/Verification.js
+++ b/packages/unit-testing/stubs/pgp/Verification.js
@@ -1,0 +1,38 @@
+define(['./VerificationSignature'], function (VerificationSignature) {
+    /**
+     * Returns a new instance of pgp.Verification used to hold PGP signature verification results.
+     *
+     * @class Verification
+     * @classdesc Stores PGP verification results.
+     * @constructor
+     * @protected
+     *
+     * @since 2022.2
+     */
+    function Verification() {
+        /**
+         * Indicates whether verification succeeded.
+         * @name Verification#verified
+         * @type {boolean|null}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.verified = undefined;
+
+        /**
+         * List of individual verifications, one per each signature.
+         * @name Verification#signatures
+         * @type {VerificationSignature[]|null}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.signatures = undefined;
+
+    }
+
+    return new Verification();
+});

--- a/packages/unit-testing/stubs/pgp/VerificationSignature.js
+++ b/packages/unit-testing/stubs/pgp/VerificationSignature.js
@@ -1,0 +1,60 @@
+define(['./KeyId'], function (KeyId) {
+    /**
+     * Returns a new instance of pgp.VerificationSignature used to hold the verification result for one signature.
+     *
+     * @class VerificationSignature
+     * @classdesc Stores a verification result for single signature.
+     * @constructor
+     * @protected
+     *
+     * @since 2022.2
+     */
+    function VerificationSignature() {
+        /**
+         * Indicates whether verification was successful for a signature.
+         * @name VerificationSignature#verified
+         * @type {boolean}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.verified = undefined;
+
+        /**
+         * ID of the (sub)key that was used for signing.
+         * @name VerificationSignature#keyId
+         * @type {KeyId}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.keyId = undefined;
+
+        /**
+         * Date when the message was signed.
+         * @name VerificationSignature#dateSigned
+         * @type {Date}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.dateSigned = undefined;
+
+        /**
+         * List of problems for more fine-grained decision-making.
+         * @name VerificationSignature#problems
+         * @type {string[]}
+         * @readonly
+         * @throws {SuiteScriptError} READ_ONLY_PROPERTY when setting the property is attempted
+         *
+         * @since 2022.2
+         */
+        this.problems = undefined;
+
+    }
+
+    return new VerificationSignature();
+});

--- a/packages/unit-testing/stubs/pgp/pgp.js
+++ b/packages/unit-testing/stubs/pgp/pgp.js
@@ -1,0 +1,159 @@
+define(['./Config', './Key', './Message', './MessageData', './Verification', '../crypto/certificate/Signer'], function (Config, Key, Message, MessageData, Verification, Signer) {
+    /**
+     * SuiteScript PGP module
+	 * Used for secure messaging, file encryption, and document signing. Based on OpenPGP encryption standards.
+     *
+     * @module N/pgp
+     * @NApiVersion 2.1
+     *
+     */
+    var pgp = function () { };
+
+    /**
+     * Creates a new pgp.Config object. A configuration object stores general configuration options that can be used for message decryption.
+     * @restriction Server SuiteScript only
+     * @governance none
+     *
+     * @param {Object} [options]
+     * @param {boolean} [options.allowMessagesWithoutIntegrityProtection] Allows messages without integrity protection on configuration objects. Default value is false.
+     * @param {boolean} [options.allowInsecureDecryptionWithSigningKeys] Enables decryption that is not secured with signing keys on configuration objects. Default value is false.
+     * @param {boolean} [options.useRelaxedSignatureParsing] Allows relaxed signature parsing for configuration objects. Default value is false.
+     * @return {Config}
+     *
+     * @since 2022.2
+     */
+    pgp.prototype.createConfig = function (options) { };
+
+    /**
+     * Creates a new pgp.MessageData object. A message data object stores message content with metadata.
+     * @restriction Server SuiteScript only
+     * @governance none
+     *
+     * @param {Object} options
+     * @param {string} options.content Content of the message.
+     * @param {string} [options.filename] File name if the message represents a file, empty string otherwise.
+     * @param {Date} [options.date] Date of the message or modification date of the file. Default value = new Date().
+     * @param {string} [options.format] Literal data packet type. Default value = Format.UTF8, if content is a string. Format.BINARY otherwise.
+     * @return {MessageData}
+     *
+     * @since 2022.2
+     */
+    pgp.prototype.createMessageData = function (options) { };
+
+    /**
+     * Creates a certificate.Signer object for signing plain strings.
+	 * If the given PGP key contains multiple valid signing sub keys, the most recently added will be used. This behavior is consistent with MessageData.encrypt(options) method.
+     * @restriction Server SuiteScript only
+     * @governance 10 units
+     *
+     * @param {Object} options
+     * @param {Key} options.key The PGP key.
+     * @param {string} options.algorithm Hash algorithm.
+     * @return {Signer}
+     *
+     * @throws {SuiteScriptError} UNSUPPORTED_COMBINATION_OF_KEY_AND_HASH_ALGORITHMS the given key's encryption algorithm is not compatible with the given hash algorithm.
+	 * @throws {SuiteScriptError} PGP_NO_SIGNING_KEY_FOUND_IN_KEY_PARAM_1 no valid signing (sub)keys are found in the given key.
+     *
+     * @since 2022.2
+     */
+    pgp.prototype.createSigner = function (options) { };
+
+    /**
+     * Creates an empty verification object.
+     * @restriction Server SuiteScript only
+     * @governance none
+     *
+     * @return {Verification}
+     *
+     * @since 2022.2
+     */
+    pgp.prototype.createVerification = function () { };
+
+	/**
+	 * @typedef {Object} Secret
+	 * @property {string} scriptId
+	 */
+
+    /**
+     * Loads a PGP key from a secret.
+     * @restriction Server SuiteScript only
+     * @governance none
+     *
+     * @param {Object} options
+     * @param {Secret} options.secret Secret that contains a PGP key in ASCII-armored format.
+     * @param {Secret} [options.password] Secret that contains a password to unlock the key. Applicable for private keys.
+     * @return {Key}
+     *
+     * @throws {SuiteScriptError} REFERENCED_SECRET_IS_NOT_AVAILABLE if the secret/password parameter references a non-existing secret, or you lack permission.
+	 * @throws {SuiteScriptError} PGP_NONSTANDARD_KEY_DOES_NOT_COMPLY_WITH_PGP_KEY_FORMAT if parsing of the key fails.
+	 * @throws {SuiteScriptError} PGP_YOU_CANNOT_PROVIDE_PASSWORD_FOR_A_PUBLIC_KEY if you provide a password, but the key is public.
+	 * @throws {SuiteScriptError} PGP_INVALID_KEY_PASSWORD if you provide a password, but it is wrong or the private key is not password protected.
+	 * @throws {SuiteScriptError} PGP_THIS_KEY_IS_PASSWORD_PROTECTED if you do not provide any password, but the private key is password protected.
+     *
+     * @since 2022.2
+     */
+    pgp.prototype.loadKeyFromSecret = function (options) { };
+
+    /**
+     * Parses a PGP message.
+     * @restriction Server SuiteScript only
+     * @governance none
+     *
+     * @param {Object} options
+     * @param {string} options.value ASCII armored representation of the message.
+     * @return {Message}
+     *
+     * @since 2022.2
+     */
+    pgp.prototype.parseMessage = function (options) { };
+
+    /**
+     * Parses an existing PGP key.
+     * @restriction Server SuiteScript only
+     * @governance none
+     *
+     * @param {Object} options
+     * @param {string} options.value PGP key value to parse.
+     * @param {string} [options.password] Password used to unlock an encrypted PGP private key.
+     * @return {Key}
+     *
+     * @throws {SuiteScriptError} PGP_NONSTANDARD_KEY_DOES_NOT_COMPLY_WITH_PGP_KEY_FORMAT if parsing of the key fails.
+	 * @throws {SuiteScriptError} PGP_YOU_CANNOT_PROVIDE_PASSWORD_FOR_A_PUBLIC_KEY if you provide a password when the key is public.
+	 * @throws {SuiteScriptError} PGP_INVALID_KEY_PASSWORD if you provide a wrong password or the private key is not password protected.
+	 * @throws {SuiteScriptError} PGP_THIS_KEY_IS_PASSWORD_PROTECTED if you don't provide any password, but the private key is password protected.
+     *
+     * @since 2022.2
+     */
+    pgp.prototype.parseKey = function (options) { };
+
+    /**
+     * Holds the values for available compression algorithms.
+	 * Use this enum to set the value of the options.compressionAlgorithm parameter of the MessageData.encrypt(options) method.
+     * @readonly
+     * @enum {string}
+     */
+    function pgpCompressionAlgorithm() {
+        this.ZLIB = 'ZLIB';
+    }
+
+    pgp.prototype.CompressionAlgorithm = new pgpCompressionAlgorithm();
+
+    /**
+     * Literal data packet type.
+	 * Use this enum to set the value for the options.format parameter of the pgp.createMessageData(options) method.
+     * @readonly
+     * @enum {string}
+     */
+    function pgpFormat() {
+        this.UTF8 = 'UTF8';
+        this.BINARY = 'BINARY';
+    }
+
+    pgp.prototype.Format = new pgpFormat();
+
+    /**
+     * @exports N/pgp
+     * @namespace pgp
+     */
+    return new pgp();
+});


### PR DESCRIPTION
## Summary

Adds SuiteScript unit-testing stubs for the N/pgp module, including:

- N/pgp
- N/pgp/config
- N/pgp/key
- N/pgp/keyId
- N/pgp/message
- N/pgp/messageData
- N/pgp/verification
- N/pgp/verificationSignature

Also wires the new stubs into SuiteCloudJestConfiguration CORE_STUBS so Jest can resolve the module paths.

## Validation

- Compared stub APIs, object members, enums, parameters, and documented errors against Oracle N/pgp SuiteScript documentation.

Closes #943 