### PR TITLE
TS-Core: Remove obsolete VS Code validation option

### DIFF
--- a/packages/vscode-extension/src/commands/DeployValidateCommon.ts
+++ b/packages/vscode-extension/src/commands/DeployValidateCommon.ts
@@ -36,7 +36,6 @@ export default abstract class DeployValidateCommon extends BaseAction {
 			this.statusBarMessage = this.translationService.getMessage(DEPLOY.DEPLOYING);
 		} else {
 			this.statusBarMessage = this.translationService.getMessage(VALIDATE.VALIDATING);
-			this.commandOptions.server = 'T';
 		}
 	}
 


### PR DESCRIPTION
Removing the server option as its not needed anymore and it emits a warining in VSCODE.