### PR TITLE
fix(unit-testing): bump package version to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7285,7 +7285,7 @@
 		},
 		"packages/unit-testing": {
 			"name": "@oracle/suitecloud-unit-testing",
-			"version": "1.7.0",
+			"version": "1.9.0",
 			"license": "UPL-1.0",
 			"dependencies": {
 				"@babel/preset-env": "7.26.0",

--- a/packages/sdk-core/resources/templates/project/unittest/package.json.template
+++ b/packages/sdk-core/resources/templates/project/unittest/package.json.template
@@ -7,6 +7,6 @@
   "devDependencies": {
 	"jest": "30.4.2",
     "@types/jest": "30.4.2",
-    "@oracle/suitecloud-unit-testing": "^1.8.0"
+    "@oracle/suitecloud-unit-testing": "^1.9.0"
   }
 }

--- a/packages/unit-testing/package.json
+++ b/packages/unit-testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@oracle/suitecloud-unit-testing",
-	"version": "1.7.0",
+	"version": "1.9.0",
 	"license": "UPL-1.0",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
- bump `@oracle/suitecloud-unit-testing` to 1.9.0
- align the workspace lockfile version
- update generated unit-testing projects to use `^1.9.0`

## Verification
- `npm run build --workspace @oracle/suitecloud-sdk-core`
- `npm test --workspace @oracle/suitecloud-cli -- --runInBand` (50 suites, 285 tests passed)