### PR TITLE
Increase project command timeout to 15 minutes

### DIFF
--- a/packages/node-cli/__test__/commands/project/ProjectCommandExecutor.test.js
+++ b/packages/node-cli/__test__/commands/project/ProjectCommandExecutor.test.js
@@ -11,6 +11,31 @@ const {
 } = require('@oracle/suitecloud-sdk-core').commands;
 
 describe('ProjectCommandExecutor', () => {
+	it('should use a 15-minute timeout by default', async () => {
+		const sendProjectRequest = jest.fn().mockResolvedValue({
+			statusCode: 200,
+			body: JSON.stringify({ status: 'SUCCESS', data: [] }),
+		});
+
+		await executeProjectCommand(
+			{
+				command: PROJECT_COMMAND.DEPLOY,
+				projectFolder: '/tmp/project',
+				hostName: 'system.netsuite.com',
+				accessToken: 'token',
+			},
+			{
+				createProjectArchive: async () => '/tmp/project.zip',
+				deleteFile: async () => undefined,
+				sendProjectRequest,
+			}
+		);
+
+		expect(sendProjectRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeoutMs: 15 * 60 * 1000 })
+		);
+	});
+
 	it('should return an error result when execution input is missing', async () => {
 		const createProjectArchive = jest.fn();
 		const sendProjectRequest = jest.fn();

--- a/packages/sdk-core/src/commands/project/ProjectCommandExecutor.ts
+++ b/packages/sdk-core/src/commands/project/ProjectCommandExecutor.ts
@@ -27,7 +27,7 @@ import {
 	type ProjectCommandLogInput,
 } from './result/ProjectCommandLog';
 
-const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
 
 type ProjectCommandDependencies = {
 	createProjectArchive?: (projectFolder: string) => Promise<string>;


### PR DESCRIPTION
## Summary

- Increase the default project command timeout from 5 to 15 minutes.
- Add regression coverage for the default timeout.

Backport of #1159.